### PR TITLE
Fix credential binding in sonar maven build

### DIFF
--- a/jenkins/jobs/cosmic_jobs.groovy
+++ b/jenkins/jobs/cosmic_jobs.groovy
@@ -824,7 +824,7 @@ FOLDERS.each { folderName ->
       colorizeOutput('xterm')
       timestamps()
       credentialsBinding {
-          usernamePassword('SONAR_RUNNER_USERNAME', 'SONAR_RUNNER_PASSWORD', 'SONAR_RUNNER_PASSWORD_PARAM')
+          usernamePassword('SONAR_RUNNER_USERNAME', 'SONAR_RUNNER_PASSWORD', injectJobVariable(SONAR_RUNNER_PASSWORD_PARAM))
       }
     }
     customWorkspace(injectJobVariable(CUSTOM_WORKSPACE_PARAM))


### PR DESCRIPTION
Credentials were not being correctly bound to the variables until the job was opened and saved in the UI.
This PR attempts to fix that.

A test build with the changes in this PR is running here: https://beta-jenkins.mcc.schubergphilis.com/job/cosmic-dev/job/tracking-repo-build/2/
