### PR TITLE
Have master build job run in a normal executor

### DIFF
--- a/jenkins/jobs/cosmic_jobs.groovy
+++ b/jenkins/jobs/cosmic_jobs.groovy
@@ -258,11 +258,8 @@ FOLDERS.each { folderName ->
 
   freeStyleJob(trackingRepoMasterBuild) {
     displayName('Cosmic master full build')
-    label(executorLabelMct)
+    label(DEFAULT_EXECUTOR)
     concurrentBuild()
-    throttleConcurrentBuilds {
-      maxPerNode(1)
-    }
     logRotator {
       numToKeep(50)
       artifactNumToKeep(10)


### PR DESCRIPTION
The master build for cosmic is a simple job that triggers the full build multijob. This one can run in a normal executor.
