### PR TITLE
Enable maven deploy

### DIFF
--- a/jenkins/jobs/cosmic_jobs.groovy
+++ b/jenkins/jobs/cosmic_jobs.groovy
@@ -905,6 +905,7 @@ FOLDERS.each { folderName ->
     concurrentBuild(true)
     goals('clean')
     goals('install')
+    goals('deploy')
     goals('-Pdeveloper')
     goals('-Psystemvm')
     goals('-Psonar-ci-cosmic')

--- a/jenkins/jobs/cosmic_jobs.groovy
+++ b/jenkins/jobs/cosmic_jobs.groovy
@@ -1040,13 +1040,12 @@ FOLDERS.each { folderName ->
         }
       }
       publishers {
-        if(repoName != 'cosmic-client') {
-          archiveJunit(makePatternList(MAVEN_REPORTS)) {
-            retainLongStdout(true)
-            testDataPublishers {
-                publishTestStabilityData()
-            }
+        archiveJunit(makePatternList(MAVEN_REPORTS)) {
+          retainLongStdout(true)
+          testDataPublishers {
+              publishTestStabilityData()
           }
+          allowEmptyResults(repoName.matches('cosmic-(client|checkstyle)'))
         }
         if(!isDevFolder) {
           slackNotifications {


### PR DESCRIPTION
This PR adds the deploy maven goal to the maven job.
It also, allows for empty unit test reports in the cosmic-checkstyle PR build.
