### PR TITLE
Include release job in top level cosmic jobs category

### DIFF
--- a/jenkins/jobs/cosmic_jobs.groovy
+++ b/jenkins/jobs/cosmic_jobs.groovy
@@ -450,7 +450,7 @@ FOLDERS.each { folderName ->
     label(executorLabelMct)
     concurrentBuild()
     throttleConcurrentBuilds {
-      maxPerNode(1)
+      categories([TOP_LEVEL_COSMIC_JOBS_CATEGORY])
     }
     logRotator {
       numToKeep(50)


### PR DESCRIPTION
This will present the release job running in the same node as the master and branch (full) builds
