### PR TITLE
Force maven build to re-download dependencies

### DIFF
--- a/jenkins/jobs/cosmic_jobs.groovy
+++ b/jenkins/jobs/cosmic_jobs.groovy
@@ -1082,6 +1082,7 @@ FOLDERS.each { folderName ->
     goals('clean')
     goals('install')
     goals('deploy')
+    goals('-U')
     goals('-Pdeveloper')
     goals('-Psystemvm')
     goals('-Psonar-ci-cosmic')


### PR DESCRIPTION
Changes made to cosmic or to a submodule won't be picked up in builds if the respective artefact exists in the local maven repo. Adding the `-U` option forces maven to re-download dependencies.

This will slow down the build, but will ensure that builds run against the most up to date artefacts.
