### PR TITLE
Check for changes in pom.xml only when preparing next development cycle

### DIFF
--- a/jenkins/jobs/cosmic_jobs.groovy
+++ b/jenkins/jobs/cosmic_jobs.groovy
@@ -1268,7 +1268,7 @@ FOLDERS.each { folderName ->
     steps {
       shell(makeMultiline([
         'mvn versions:force-releases',
-        'if [ -z "$(git status -su)" ]; then',
+        'if [ -z "$(git status -su -- pom.xml)" ]; then',
         '  echo "==> No dependencies changed"',
         'else',
         '  echo "==> Committing dependency chages"',


### PR DESCRIPTION
We should check for changes in pom.xml only because there will be temporary files created that count as untracked files and we are not interested in those.
