### PR TITLE
Fix path to python unit-tests report

### DIFF
--- a/jenkins/jobs/marvin_jobs.groovy
+++ b/jenkins/jobs/marvin_jobs.groovy
@@ -273,7 +273,7 @@ multiJob(MARVIN_BUILD_JOB) {
         }
         archiveXUnit {
             jUnit {
-                pattern('nosetests.xml')
+                pattern('marvin/nosetests.xml')
             }
         }
     }
@@ -411,7 +411,7 @@ multiJob(RELEASE_JOB) {
         }
         archiveXUnit {
             jUnit {
-                pattern('nosetests.xml')
+                pattern('marvin/nosetests.xml')
             }
         }
     }


### PR DESCRIPTION
The workspace of the top-level build jobs is divided between cosmic and marvin, therefore the path to the python unit-test reports is incomplete. This PR fixes that.
