### PR TITLE
Fix path to apidoc

### DIFF
--- a/jenkins/jobs/marvin_jobs.groovy
+++ b/jenkins/jobs/marvin_jobs.groovy
@@ -627,7 +627,7 @@ freeStyleJob(BUILD_API_JOB) {
     }
     steps {
         shell("rm -rf ./cloudstackAPI")
-        shell("python codegenerator.py -s ../../cosmic/cosmic-core/tools/apidoc/target/commands.xml")
+        shell("python codegenerator.py -s ../../cosmic/cosmic-core/apidoc/target/commands.xml")
     }
 }
 


### PR DESCRIPTION
This will be needed once the tools maven module is gone.

Merge after: MissionCriticalCloud/blackhole#3
