### PR TITLE
Fix release job

### DIFF
--- a/jenkins/jobs/cosmic_jobs.groovy
+++ b/jenkins/jobs/cosmic_jobs.groovy
@@ -345,7 +345,7 @@ FOLDERS.each { folderName ->
                 stringParam(MAVEN_RELEASE_VERSION_PARAM, "", 'Release version')
             }
             concurrentBuild(false)
-            label(DEFAULT_EXECUTOR)
+            label(executorLabelMct)
             logRotator {
                 numToKeep(50)
                 artifactNumToKeep(10)

--- a/jenkins/jobs/cosmic_jobs.groovy
+++ b/jenkins/jobs/cosmic_jobs.groovy
@@ -19,7 +19,6 @@ def TESTS_PARAM = 'tests'
 
 def TOP_LEVEL_COSMIC_JOBS_CATEGORY = 'top-level-cosmic-jobs'
 
-def MAVEN_OPTIONS_RELEASE_JOB = '-Xmx2048m -Xms2048m'
 def MAVEN_RELEASE_VERSION_PARAM = 'releaseVersion'
 def MAVEN_RELEASE_NO_PUSH = '-DpushChanges=false -DlocalCheckout=true'
 
@@ -372,7 +371,6 @@ FOLDERS.each { folderName ->
             preBuildSteps {
                 shell("git checkout master")
             }
-            mavenOpts(MAVEN_OPTIONS_RELEASE_JOB)
             goals("release:prepare release:perform -Pdeveloper,systemvm -DreleaseVersion=${injectJobVariable(MAVEN_RELEASE_VERSION_PARAM)} ${(isDevFolder ? MAVEN_RELEASE_NO_PUSH : '')}")
         }
 

--- a/jenkins/jobs/cosmic_jobs.groovy
+++ b/jenkins/jobs/cosmic_jobs.groovy
@@ -371,7 +371,7 @@ FOLDERS.each { folderName ->
             preBuildSteps {
                 shell("git checkout master")
             }
-            goals("release:prepare release:perform -Pdeveloper,systemvm -DreleaseVersion=${injectJobVariable(MAVEN_RELEASE_VERSION_PARAM)} ${(isDevFolder ? MAVEN_RELEASE_NO_PUSH : '')}")
+            goals("release:prepare release:perform -Psystemvm -DreleaseVersion=${injectJobVariable(MAVEN_RELEASE_VERSION_PARAM)} ${(isDevFolder ? MAVEN_RELEASE_NO_PUSH : '')}")
         }
 
         // Build for a branch of cosmic
@@ -663,7 +663,6 @@ FOLDERS.each { folderName ->
             goals('deploy')
         }
         goals('-U')
-        goals('-Pdeveloper')
         goals('-Psystemvm')
         goals('-Psonar-ci-cosmic')
         goals("-Dcosmic.dir=\"${injectJobVariable(CUSTOM_WORKSPACE_PARAM)}\"")


### PR DESCRIPTION
Removed maven options set in the release job because those do not propagate to the release job. Instead these will be set in the `.mvn/jvm.config` file in the main repo.

Have release jobs run in the bubble slaves because of the non-default ports we use internally for nexus.

Do not build the project using the developer profile, since all it does now is to enable simpler options that are useful for development but different from production (and we want to test as close to production as possible).
