### PR TITLE
Remove references to developer profile

### DIFF
--- a/jenkins/jobs/cosmic_jobs.groovy
+++ b/jenkins/jobs/cosmic_jobs.groovy
@@ -65,7 +65,6 @@ def COSMIC_BUILD_ARTEFACTS = [
         'cosmic-client/target/conf/',
         'cosmic-client/target/pythonlibs/',
         'cosmic-client/target/utilities/',
-        'cosmic-core/developer/developer-prefill.sql',
         'cosmic-core/test/integration/',
         'cosmic-core/**/target/*.jar',
         'cosmic-plugin-hypervisor-kvm/target/*.jar',

--- a/jenkins/jobs/marvin_jobs.groovy
+++ b/jenkins/jobs/marvin_jobs.groovy
@@ -530,7 +530,6 @@ mavenJob(BUILD_COSMIC_JOB) {
     goals('clean')
     goals('package')
     goals('-T4')
-    goals('-Pdeveloper')
     goals('-Psystemvm')
 }
 


### PR DESCRIPTION
This is mean to remove a profile that is no longer needed for the builds (since PR MissionCriticalCloud/cosmic#50), but should not harm older builds because the only thing the profile is doing is including the `apidocs` module.
