### PR TITLE
MANAGEMENT_SERVER_LOG_FILE and MANAGEMENT_SERVER_LOG_ROTATION are not job variables

### DIFF
--- a/jenkins/jobs/cosmic_jobs.groovy
+++ b/jenkins/jobs/cosmic_jobs.groovy
@@ -711,8 +711,8 @@ FOLDERS.each { folderName ->
         goals('-Psystemvm')
         goals('-Psonar-ci-cosmic')
         goals("-Dcosmic.dir=\"${injectJobVariable(CUSTOM_WORKSPACE_PARAM)}\"")
-        goals("-Dlog.file.management.server=\"${injectJobVariable(MANAGEMENT_SERVER_LOG_FILE)}\"")
-        goals("-Dlog.rotation.management.server=\"${injectJobVariable(MANAGEMENT_SERVER_LOG_ROTATION)}\"")
+        goals("-Dlog.file.management.server=\"${MANAGEMENT_SERVER_LOG_FILE}\"")
+        goals("-Dlog.rotation.management.server=\"${MANAGEMENT_SERVER_LOG_ROTATION}\"")
     }
 
     mavenJob(mavenSonarBuild) {


### PR DESCRIPTION
This fixes the `management.log_IS_UNDEFINED` log file name

Build running: https://beta-jenkins.mcc.schubergphilis.com/job/cosmic-dev/job/0020-full-build/2/