### PR TITLE
Job DSL script names may only contain letters, digits and underscores

### DIFF
--- a/jenkins/jobs/cosmic_microservices_jobs.groovy
+++ b/jenkins/jobs/cosmic_microservices_jobs.groovy
@@ -132,7 +132,7 @@ FOLDERS.each { folderName ->
             steps {
                 dsl {
                     if (!isDevFolder) {
-                        external('jenkins/jobs/cosmic-microservices_jobs.groovy')
+                        external('jenkins/jobs/cosmic_microservices_jobs.groovy')
                     }
                 }
             }


### PR DESCRIPTION
Correcting the actual filename used by the job