### PR TITLE
Remove the slackNotifications from the Cosmic DSL.

### DIFF
--- a/jenkins/jobs/cosmic_jobs.groovy
+++ b/jenkins/jobs/cosmic_jobs.groovy
@@ -260,16 +260,6 @@ FOLDERS.each { folderName ->
                             publishTestStabilityData()
                         }
                     }
-                    slackNotifications {
-                        notifyBuildStart()
-                        notifyAborted()
-                        notifyFailure()
-                        notifyNotBuilt()
-                        notifyUnstable()
-                        notifyBackToNormal()
-                        includeTestSummary()
-                        showCommitList()
-                    }
                     githubCommitNotifier()
                 }
             }
@@ -346,16 +336,6 @@ FOLDERS.each { folderName ->
                         testDataPublishers {
                             publishTestStabilityData()
                         }
-                    }
-                    slackNotifications {
-                        notifyBuildStart()
-                        notifyAborted()
-                        notifyFailure()
-                        notifyNotBuilt()
-                        notifyUnstable()
-                        notifyBackToNormal()
-                        includeTestSummary()
-                        showCommitList()
                     }
                 }
             }


### PR DESCRIPTION
The newer DSL plugin doesn't support the Slack plugin natively. It however does offer a generic DSL to configure Slack. But, in order to do that, we must upgrade our pinned Slack version to the latest version.

Until we fixed the whole chain, I'm removing the Slack integration from the DSL. It however will still be available in Jenkins as it will keep it's configuration.

https://github.com/jenkinsci/job-dsl-plugin/blob/aa3b9715b361e06850948944793aa7479d2dbc2b/docs/Migration.md#slack