### PR TITLE
Removing MCT from executor labels

### DIFF
--- a/jenkins/jobs/bubble_templates_jobs.groovy
+++ b/jenkins/jobs/bubble_templates_jobs.groovy
@@ -22,7 +22,7 @@ def TOP_LEVEL_COSMIC_JOBS_CATEGORY = 'top-level-cosmic-jobs'
 
 def MCCD_JENKINS_GITHUB_CREDENTIALS = 'f4ec9d6e-49fb-497c-bd1f-e42d88e105da'
 
-def DEFAULT_EXECUTOR = 'executor-mct'
+def DEFAULT_EXECUTOR = 'executor'
 
 def WORKSPACES = [
         '${WORKSPACE}/cosmic-centos-7',

--- a/jenkins/jobs/cosmic_helm_repo_jobs.groovy
+++ b/jenkins/jobs/cosmic_helm_repo_jobs.groovy
@@ -30,7 +30,6 @@ def MCCD_JENKINS_GITHUB_CREDENTIALS = 'f4ec9d6e-49fb-497c-bd1f-e42d88e105da'
 def MCCD_JENKINS_AWS_CREDENTIALS = '948b39fd-61fd-4669-8afd-55e46c1c03ee'
 
 def DEFAULT_EXECUTOR = 'executor'
-def DEFAULT_EXECUTOR_MCT = 'executor-mct'
 
 def cosmicMasterBuild = "0001-cosmic-helm-repo-master-build"
 def cosmicPullRequestBuild = "0002-cosmic-helm-repo-pull-request-build"
@@ -80,7 +79,7 @@ freeStyleJob(SEED_JOB) {
 }
 
 multiJob("${FOLDER_NAME}/" + cosmicMasterBuild) {
-    label(DEFAULT_EXECUTOR_MCT)
+    label(DEFAULT_EXECUTOR)
     concurrentBuild()
     logRotator {
         numToKeep(50)
@@ -129,7 +128,7 @@ multiJob("${FOLDER_NAME}/" + cosmicPullRequestBuild) {
     throttleConcurrentBuilds {
         categories([TOP_LEVEL_COSMIC_JOBS_CATEGORY])
     }
-    label(DEFAULT_EXECUTOR_MCT)
+    label(DEFAULT_EXECUTOR)
     logRotator {
         numToKeep(50)
         artifactNumToKeep(10)
@@ -186,7 +185,7 @@ multiJob(fullBuild) {
         stringParam(GIT_REPO_BRANCH_PARAM, 'master', 'Branch to be built')
     }
     customWorkspace(injectJobVariable(CUSTOM_WORKSPACE_PARAM))
-    label(DEFAULT_EXECUTOR_MCT)
+    label(DEFAULT_EXECUTOR)
     concurrentBuild()
     throttleConcurrentBuilds {
         maxPerNode(1)
@@ -219,7 +218,7 @@ freeStyleJob(makeBuild) {
         stringParam(CUSTOM_WORKSPACE_PARAM, WORKSPACE_VAR, 'A custom workspace to use for the job')
     }
     customWorkspace(injectJobVariable(CUSTOM_WORKSPACE_PARAM))
-    label(DEFAULT_EXECUTOR_MCT)
+    label(DEFAULT_EXECUTOR)
     concurrentBuild()
     throttleConcurrentBuilds {
         maxPerNode(1)
@@ -243,7 +242,7 @@ freeStyleJob(makeLintBuild) {
         stringParam(CUSTOM_WORKSPACE_PARAM, WORKSPACE_VAR, 'A custom workspace to use for the job')
     }
     customWorkspace(injectJobVariable(CUSTOM_WORKSPACE_PARAM))
-    label(DEFAULT_EXECUTOR_MCT)
+    label(DEFAULT_EXECUTOR)
     concurrentBuild()
     throttleConcurrentBuilds {
         maxPerNode(1)

--- a/jenkins/jobs/cosmic_jobs.groovy
+++ b/jenkins/jobs/cosmic_jobs.groovy
@@ -92,7 +92,6 @@ def COSMIC_INTEGRATION_TESTS = [
 ]
 
 def DEFAULT_EXECUTOR = 'executor'
-def DEFAULT_EXECUTOR_MCT = 'executor-mct'
 
 // dev folder is to play with jobs.
 // Jobs defined there should never automatically trigger
@@ -122,7 +121,7 @@ FOLDERS.each { folderName ->
 
     def isDevFolder = folderName.endsWith('-dev')
     def shellPrefix = 'bash -x'
-    def executorLabelMct = DEFAULT_EXECUTOR_MCT + (isDevFolder ? '-dev' : '')
+    def executorLabelDev = DEFAULT_EXECUTOR + (isDevFolder ? '-dev' : '')
 
     folder(folderName) {
         primaryView(cosmicView)
@@ -194,7 +193,7 @@ FOLDERS.each { folderName ->
                 textParam(TESTS_PARAM, makeMultiline(isDevFolder ? subArray(COSMIC_INTEGRATION_TESTS) : COSMIC_INTEGRATION_TESTS), 'Set of integration tests to execute')
                 stringParam(MARVIN_CONFIG_FILE_PARAM, DEFAULT_MARVIN_CONFIG_FILE, 'Marvin file to use')
             }
-            label(executorLabelMct)
+            label(executorLabelDev)
             concurrentBuild()
             throttleConcurrentBuilds {
                 categories([TOP_LEVEL_COSMIC_JOBS_CATEGORY])
@@ -267,7 +266,7 @@ FOLDERS.each { folderName ->
             throttleConcurrentBuilds {
                 categories([TOP_LEVEL_COSMIC_JOBS_CATEGORY])
             }
-            label(executorLabelMct)
+            label(executorLabelDev)
             logRotator {
                 numToKeep(50)
                 artifactNumToKeep(10)
@@ -338,7 +337,7 @@ FOLDERS.each { folderName ->
                 stringParam(MAVEN_RELEASE_VERSION_PARAM, "", 'Release version')
             }
             concurrentBuild(false)
-            label(executorLabelMct)
+            label(executorLabelDev)
             logRotator {
                 numToKeep(50)
                 artifactNumToKeep(10)
@@ -392,7 +391,7 @@ FOLDERS.each { folderName ->
                 stringParam(MAVEN_SNAPSHOT_VERSION_PARAM, "", 'Snapshot version, include \'-SNAPSHOT\' in the version string. Example: 6.0.0.0-SNAPSHOT')
             }
             concurrentBuild(false)
-            label(executorLabelMct)
+            label(executorLabelDev)
             logRotator {
                 numToKeep(50)
                 artifactNumToKeep(10)
@@ -450,7 +449,7 @@ FOLDERS.each { folderName ->
                 stringParam(MARVIN_CONFIG_FILE_PARAM, DEFAULT_MARVIN_CONFIG_FILE, 'Marvin file to use')
             }
             customWorkspace(injectJobVariable(CUSTOM_WORKSPACE_PARAM))
-            label(executorLabelMct)
+            label(executorLabelDev)
             concurrentBuild()
             throttleConcurrentBuilds {
                 maxPerNode(1)
@@ -564,7 +563,7 @@ FOLDERS.each { folderName ->
         parameters {
             stringParam(MARVIN_CONFIG_FILE_PARAM, DEFAULT_MARVIN_CONFIG_FILE, 'Marvin file to use')
         }
-        label(executorLabelMct)
+        label(executorLabelDev)
         concurrentBuild()
         throttleConcurrentBuilds {
             maxPerNode(1)
@@ -593,7 +592,7 @@ FOLDERS.each { folderName ->
         parameters {
             stringParam(MARVIN_CONFIG_FILE_PARAM, DEFAULT_MARVIN_CONFIG_FILE, 'Marvin file to use')
         }
-        label(executorLabelMct)
+        label(executorLabelDev)
         concurrentBuild()
         throttleConcurrentBuilds {
             maxPerNode(1)
@@ -619,7 +618,7 @@ FOLDERS.each { folderName ->
             stringParam(MARVIN_CONFIG_FILE_PARAM, DEFAULT_MARVIN_CONFIG_FILE, 'Marvin file to use')
         }
         customWorkspace(injectJobVariable(CUSTOM_WORKSPACE_PARAM))
-        label(executorLabelMct)
+        label(executorLabelDev)
         concurrentBuild()
         throttleConcurrentBuilds {
             maxPerNode(1)
@@ -641,7 +640,7 @@ FOLDERS.each { folderName ->
         parameters {
             stringParam(MARVIN_CONFIG_FILE_PARAM, DEFAULT_MARVIN_CONFIG_FILE, 'Marvin file to use')
         }
-        label(executorLabelMct)
+        label(executorLabelDev)
         concurrentBuild()
         throttleConcurrentBuilds {
             maxPerNode(1)
@@ -677,7 +676,7 @@ FOLDERS.each { folderName ->
             stringParam(MARVIN_CONFIG_FILE_PARAM, DEFAULT_MARVIN_CONFIG_FILE, 'Marvin file to use')
         }
         customWorkspace(injectJobVariable(CUSTOM_WORKSPACE_PARAM))
-        label(executorLabelMct)
+        label(executorLabelDev)
         concurrentBuild()
         throttleConcurrentBuilds {
             maxPerNode(1)

--- a/jenkins/jobs/cosmic_microservices_jobs.groovy
+++ b/jenkins/jobs/cosmic_microservices_jobs.groovy
@@ -48,7 +48,6 @@ def COSMIC_BUILD_ARTEFACTS = [
 
 
 def DEFAULT_EXECUTOR = 'executor'
-def DEFAULT_EXECUTOR_MCT = 'executor-mct'
 
 def DOCKER_HOST = 'tcp://127.0.0.1:2375'
 def DOCKER_PUSH = 'mvn docker:push -Ddocker.filter=%g/%a:%l -Pproduction'
@@ -76,7 +75,7 @@ FOLDERS.each { folderName ->
     def seedJob = "${folderName}/9999-seed-job"
 
     def isDevFolder = folderName.endsWith('-dev')
-    def executorLabelMct = DEFAULT_EXECUTOR_MCT + (isDevFolder ? '-dev' : '')
+    def executorLabelDev = DEFAULT_EXECUTOR + (isDevFolder ? '-dev' : '')
 
     folder(folderName) {
         primaryView(cosmicView)
@@ -144,7 +143,7 @@ FOLDERS.each { folderName ->
         }
 
         multiJob("${folderName}/" + cosmicmicroservicesMasterBuild) {
-            label(executorLabelMct)
+            label(executorLabelDev)
             concurrentBuild()
             throttleConcurrentBuilds {
                 categories([TOP_LEVEL_COSMIC_JOBS_CATEGORY])
@@ -224,7 +223,7 @@ FOLDERS.each { folderName ->
             throttleConcurrentBuilds {
                 categories([TOP_LEVEL_COSMIC_JOBS_CATEGORY])
             }
-            label(executorLabelMct)
+            label(executorLabelDev)
             logRotator {
                 numToKeep(50)
                 artifactNumToKeep(10)
@@ -306,7 +305,7 @@ FOLDERS.each { folderName ->
             throttleConcurrentBuilds {
                 categories([TOP_LEVEL_COSMIC_JOBS_CATEGORY])
             }
-            label(executorLabelMct)
+            label(executorLabelDev)
             logRotator {
                 numToKeep(50)
                 artifactNumToKeep(10)
@@ -351,7 +350,7 @@ FOLDERS.each { folderName ->
             throttleConcurrentBuilds {
                 categories([TOP_LEVEL_COSMIC_JOBS_CATEGORY])
             }
-            label(executorLabelMct)
+            label(executorLabelDev)
             logRotator {
                 numToKeep(50)
                 artifactNumToKeep(10)
@@ -397,7 +396,7 @@ FOLDERS.each { folderName ->
                 stringParam(DOCKER_PUSH_PARAM, '', 'If we want to push to Docker')
             }
             customWorkspace(injectJobVariable(CUSTOM_WORKSPACE_PARAM))
-            label(executorLabelMct)
+            label(executorLabelDev)
             concurrentBuild()
             throttleConcurrentBuilds {
                 maxPerNode(1)

--- a/jenkins/jobs/cosmic_systemvm_jobs.groovy
+++ b/jenkins/jobs/cosmic_systemvm_jobs.groovy
@@ -18,7 +18,7 @@ def TOP_LEVEL_COSMIC_JOBS_CATEGORY = 'top-level-cosmic-jobs'
 
 def MCCD_JENKINS_GITHUB_CREDENTIALS = 'f4ec9d6e-49fb-497c-bd1f-e42d88e105da'
 
-def DEFAULT_EXECUTOR = 'executor-mct'
+def DEFAULT_EXECUTOR = 'executor'
 
 def SYSTEMVM_BUILD_ARTEFACTS = [
         'packer_output/*'


### PR DESCRIPTION
Switching to only using the hardware slaves for all jobs, this is done by setting the executor label from `executor-mct` to `executor` on all HV slaves